### PR TITLE
ワンタイムパスワード・マジックナンバーの生成処理のコード整理

### DIFF
--- a/Controller/TwoFactorAuthCustomerSmsController.php
+++ b/Controller/TwoFactorAuthCustomerSmsController.php
@@ -31,6 +31,11 @@ use Twilio\Rest\Api\V2010\Account\MessageInstance;
 class TwoFactorAuthCustomerSmsController extends TwoFactorAuthCustomerController
 {
     /**
+     * ワンタイムトークンの桁数
+     */
+    public const TOKEN_LENGTH = 6;
+
+    /**
      * SMS認証 送信先入力画面.
      *
      * @Route("/mypage/two_factor_auth/tfa/sms/send_onetime", name="plg_customer_2fa_sms_send_onetime", methods={"GET", "POST"})
@@ -184,7 +189,7 @@ class TwoFactorAuthCustomerSmsController extends TwoFactorAuthCustomerController
     {
         // ワンタイムトークン生成・保存
         $token = $this->customerTwoFactorAuthService->generateOneTimeTokenValue(
-            (int) $this->eccubeConfig->get('plugin_eccube_2fa_sms_one_time_token_length')
+            self::TOKEN_LENGTH
         );
 
         $Customer->setTwoFactorAuthOneTimeToken($this->customerTwoFactorAuthService->hashOneTimeToken($token));

--- a/Controller/TwoFactorAuthCustomerSmsController.php
+++ b/Controller/TwoFactorAuthCustomerSmsController.php
@@ -31,11 +31,6 @@ use Twilio\Rest\Api\V2010\Account\MessageInstance;
 class TwoFactorAuthCustomerSmsController extends TwoFactorAuthCustomerController
 {
     /**
-     * ワンタイムトークンの桁数
-     */
-    public const TOKEN_LENGTH = 6;
-
-    /**
      * SMS認証 送信先入力画面.
      *
      * @Route("/mypage/two_factor_auth/tfa/sms/send_onetime", name="plg_customer_2fa_sms_send_onetime", methods={"GET", "POST"})
@@ -188,9 +183,7 @@ class TwoFactorAuthCustomerSmsController extends TwoFactorAuthCustomerController
     private function sendToken($Customer, $phoneNumber)
     {
         // ワンタイムトークン生成・保存
-        $token = $this->customerTwoFactorAuthService->generateOneTimeTokenValue(
-            self::TOKEN_LENGTH
-        );
+        $token = $this->customerTwoFactorAuthService->generateOneTimeTokenValue();
 
         $Customer->setTwoFactorAuthOneTimeToken($this->customerTwoFactorAuthService->hashOneTimeToken($token));
         $Customer->setTwoFactorAuthOneTimeTokenExpire($this->customerTwoFactorAuthService->generateExpiryDate(

--- a/Entity/CustomerTrait.php
+++ b/Entity/CustomerTrait.php
@@ -59,20 +59,6 @@ trait CustomerTrait
     }
 
     /**
-     * @param string $hashedOneTimePassword
-     *
-     * @return void
-     */
-    public function createTwoFactorAuthOneTimeToken(string $hashedOneTimePassword): void
-    {
-        $now = new \DateTime();
-
-        // ワンタイムパスワードをハッシュする
-        $this->setTwoFactorAuthOneTimeToken($hashedOneTimePassword);
-        $this->setTwoFactorAuthOneTimeTokenExpire($now->modify('+5 mins'));
-    }
-
-    /**
      * @return string
      */
     public function getTwoFactorAuthOneTimeToken(): ?string

--- a/Resource/config/services.yaml
+++ b/Resource/config/services.yaml
@@ -11,3 +11,11 @@ eccube:
       limit: 30
       # インターバルを設定します。
       interval: '30 minutes'
+
+parameters:
+  env(PLUGIN_ECCUBE_2FA_SMS_ONE_TIME_TOKEN_LENGTH): '6'
+  env(PLUGIN_ECCUBE_2FA_SMS_ONE_TIME_TOKEN_EXPIRE_AFTER_SECONDS): '300'
+
+  plugin_eccube_2fa_sms_one_time_token_length: '%env(PLUGIN_ECCUBE_2FA_SMS_ONE_TIME_TOKEN_LENGTH)%'
+  plugin_eccube_2fa_sms_one_time_token_expire_after_seconds: '%env(PLUGIN_ECCUBE_2FA_SMS_ONE_TIME_TOKEN_EXPIRE_AFTER_SECONDS)%'
+

--- a/Resource/config/services.yaml
+++ b/Resource/config/services.yaml
@@ -13,9 +13,7 @@ eccube:
       interval: '30 minutes'
 
 parameters:
-  env(PLUGIN_ECCUBE_2FA_SMS_ONE_TIME_TOKEN_LENGTH): '6'
   env(PLUGIN_ECCUBE_2FA_SMS_ONE_TIME_TOKEN_EXPIRE_AFTER_SECONDS): '300'
 
-  plugin_eccube_2fa_sms_one_time_token_length: '%env(PLUGIN_ECCUBE_2FA_SMS_ONE_TIME_TOKEN_LENGTH)%'
   plugin_eccube_2fa_sms_one_time_token_expire_after_seconds: '%env(PLUGIN_ECCUBE_2FA_SMS_ONE_TIME_TOKEN_EXPIRE_AFTER_SECONDS)%'
 


### PR DESCRIPTION
> マジックナンバーを解消してほしい
> https://github.com/EC-CUBE/TwoFactorAuthCustomer42/issues/35

について、

■ createTwoFactorAuthOneTimeToken関数名の意味がないため、削除しました。
■ その代わりにCustomerTwoFactorAuthServiceにあるgenerateExpiryDate関数を利用するようにする
   -> モデルのセッター関数を利用する

