### PR TITLE
レビュー用PR_2023_03_24に関しての修正

### DIFF
--- a/Controller/TwoFactorAuthCustomerSmsController.php
+++ b/Controller/TwoFactorAuthCustomerSmsController.php
@@ -183,7 +183,9 @@ class TwoFactorAuthCustomerSmsController extends TwoFactorAuthCustomerController
     private function sendToken($Customer, $phoneNumber)
     {
         // ワンタイムトークン生成・保存
-        $token = $this->customerTwoFactorAuthService->generateOneTimeTokenValue();
+        $token = $this->customerTwoFactorAuthService->generateOneTimeTokenValue(
+            (int) $this->eccubeConfig->get('plugin_eccube_2fa_sms_one_time_token_length')
+        );
 
         $Customer->setTwoFactorAuthOneTimeToken($this->customerTwoFactorAuthService->hashOneTimeToken($token));
         $Customer->setTwoFactorAuthOneTimeTokenExpire($this->customerTwoFactorAuthService->generateExpiryDate(

--- a/PluginManager.php
+++ b/PluginManager.php
@@ -140,8 +140,8 @@ class PluginManager extends AbstractPluginManager
     protected function createPages(EntityManagerInterface $em)
     {
         foreach ($this->pages as $p) {
-            $Page = $em->getRepository(Page::class)->findOneBy(['url' => $p[0]]);
-            if (!$Page) {
+            $hasPage = $em->getRepository(Page::class)->count(['url' => $p[0]]) > 0;
+            if (!$hasPage) {
                 /** @var Page $Page */
                 $Page = $em->getRepository(Page::class)->newPage();
                 $Page->setEditType(Page::EDIT_TYPE_DEFAULT);

--- a/Resource/config/services.yaml
+++ b/Resource/config/services.yaml
@@ -1,6 +1,6 @@
 eccube:
   rate_limiter:
-    sms_send_onetime_request:
+    plg_customer_2fa_sms_send_onetime:
       # 実行するルーティングを指定します。
       route: plg_customer_2fa_sms_send_onetime
       # 実行するmethodを指定します。デフォルトはPOSTです。

--- a/Resource/config/services.yaml
+++ b/Resource/config/services.yaml
@@ -13,7 +13,9 @@ eccube:
       interval: '30 minutes'
 
 parameters:
+  env(PLUGIN_ECCUBE_2FA_SMS_ONE_TIME_TOKEN_LENGTH): '6'
   env(PLUGIN_ECCUBE_2FA_SMS_ONE_TIME_TOKEN_EXPIRE_AFTER_SECONDS): '300'
 
+  plugin_eccube_2fa_sms_one_time_token_length: '%env(PLUGIN_ECCUBE_2FA_SMS_ONE_TIME_TOKEN_LENGTH)%'
   plugin_eccube_2fa_sms_one_time_token_expire_after_seconds: '%env(PLUGIN_ECCUBE_2FA_SMS_ONE_TIME_TOKEN_EXPIRE_AFTER_SECONDS)%'
 


### PR DESCRIPTION
https://github.com/EC-CUBE/TwoFactorAuthCustomer42/pull/3#discussion_r1147157803
について、他の->findOneBy([〇〇]) === null箇所の代わりにcount関数を利用するように更新しました。

https://github.com/EC-CUBE/TwoFactorAuthCustomer42/pull/3#discussion_r1147164107
について、二段階認証SMSプラグインのワンタイムトークン長をservices.ymlで変更出来るようになりました。

https://github.com/EC-CUBE/TwoFactorAuthCustomer42/pull/3#issuecomment-1482332934
について、スロットリングパラメータはルーティング名と合わせました。