### PR TITLE
スロットリングの制限回数ミスの修正

### DIFF
--- a/Resource/config/services.yaml
+++ b/Resource/config/services.yaml
@@ -8,7 +8,7 @@ eccube:
       # スロットリングの制御方法を設定します。ip・customerを指定できます。
       type: [ 'ip', 'customer' ]
       # 試行回数を設定します。
-      limit: 30
+      limit: 5
       # インターバルを設定します。
       interval: '30 minutes'
 


### PR DESCRIPTION
TwoFactorAuthCustomerSms42の試行回数をTwoFactorAuthCustomer42の試行回数と合わせました。

https://github.com/EC-CUBE/TwoFactorAuthCustomerSms42/issues/11
