### PR TITLE
SMSトークンの長さ設定とSMSトークンの有効期限設定を消す

### DIFF
--- a/Controller/TwoFactorAuthCustomerSmsController.php
+++ b/Controller/TwoFactorAuthCustomerSmsController.php
@@ -183,14 +183,10 @@ class TwoFactorAuthCustomerSmsController extends TwoFactorAuthCustomerController
     private function sendToken($Customer, $phoneNumber)
     {
         // ワンタイムトークン生成・保存
-        $token = $this->customerTwoFactorAuthService->generateOneTimeTokenValue(
-            (int) $this->eccubeConfig->get('plugin_eccube_2fa_sms_one_time_token_length')
-        );
+        $token = $this->customerTwoFactorAuthService->generateOneTimeTokenValue();
 
         $Customer->setTwoFactorAuthOneTimeToken($this->customerTwoFactorAuthService->hashOneTimeToken($token));
-        $Customer->setTwoFactorAuthOneTimeTokenExpire($this->customerTwoFactorAuthService->generateExpiryDate(
-            (int) $this->eccubeConfig->get('plugin_eccube_2fa_sms_one_time_token_expire_after_seconds')
-        ));
+        $Customer->setTwoFactorAuthOneTimeTokenExpire($this->customerTwoFactorAuthService->generateExpiryDate());
         $this->entityManager->persist($Customer);
         $this->entityManager->flush();
 

--- a/Resource/config/services.yaml
+++ b/Resource/config/services.yaml
@@ -11,11 +11,3 @@ eccube:
       limit: 30
       # インターバルを設定します。
       interval: '30 minutes'
-
-parameters:
-  env(PLUGIN_ECCUBE_2FA_SMS_ONE_TIME_TOKEN_LENGTH): '6'
-  env(PLUGIN_ECCUBE_2FA_SMS_ONE_TIME_TOKEN_EXPIRE_AFTER_SECONDS): '300'
-
-  plugin_eccube_2fa_sms_one_time_token_length: '%env(PLUGIN_ECCUBE_2FA_SMS_ONE_TIME_TOKEN_LENGTH)%'
-  plugin_eccube_2fa_sms_one_time_token_expire_after_seconds: '%env(PLUGIN_ECCUBE_2FA_SMS_ONE_TIME_TOKEN_EXPIRE_AFTER_SECONDS)%'
-


### PR DESCRIPTION
※ TwoFactorAuthCustomer42プラグインのトークンの長さ設定とSMS有効期限設定を利用するようになる https://github.com/EC-CUBE/TwoFactorAuthCustomer42/pull/42